### PR TITLE
chore: support global.priorityClassName

### DIFF
--- a/charts/steadybit-extension-splunk-platform/Chart.yaml
+++ b/charts/steadybit-extension-splunk-platform/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-splunk-platform
 description: Steadybit Splunk Cloud Platform and Splunk Enterprise extension Helm chart for Kubernetes.
-version: 1.0.8
+version: 1.0.9
 appVersion: v1.0.5
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-splunk-platform/templates/deployment.yaml
+++ b/charts/steadybit-extension-splunk-platform/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.priorityClassName }}
+      {{- with (.Values.priorityClassName | default (dig "priorityClassName" nil (.Values.global | default dict))) }}
       priorityClassName: {{ . }}
       {{- end }}
       {{- with .Values.podSecurityContext }}


### PR DESCRIPTION
## Summary
- Update `priorityClassName` template to fall back to `global.priorityClassName`
- Bump chart version to 1.0.9