### PR TITLE
feat: support if-none-match for the extension list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Support if-none-match for the extension list endpoint
+
 ## v1.0.6
 
 - feat(chart): split image.name into image.registry + image.name

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"time"
+
 	_ "github.com/KimMachineGun/automemlimit" // By default, it sets `GOMEMLIMIT` to 90% of cgroup's memory limit.
 	"github.com/rs/zerolog"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
@@ -21,6 +23,8 @@ import (
 	_ "go.uber.org/automaxprocs" // Importing automaxprocs automatically adjusts GOMAXPROCS.
 )
 
+var startedAt = time.Now().Format(time.RFC3339)
+
 func main() {
 	extlogging.InitZeroLog()
 
@@ -32,11 +36,11 @@ func main() {
 
 	config.ParseConfiguration()
 
-	exthttp.RegisterHttpHandler("/", exthttp.GetterAsHandler(getExtensionList))
-
 	splunkClient := extalert.NewSplunkClient()
 	discovery_kit_sdk.Register(extalert.NewAlertDiscovery(splunkClient))
 	action_kit_sdk.RegisterAction(extalert.NewAlertCheckAction(splunkClient))
+
+	exthttp.RegisterHttpHandler("/", exthttp.IfNoneMatchHandler(func() string { return startedAt }, exthttp.GetterAsHandler(getExtensionList)))
 
 	extsignals.ActivateSignalHandlers()
 	action_kit_sdk.RegisterCoverageEndpoints()


### PR DESCRIPTION
## Summary
- Wrap the `"/"` index handler with `exthttp.IfNoneMatchHandler` using a startup timestamp as ETag
- Allows clients to skip re-fetching the unchanged extension list via `If-None-Match` header
- Move index handler registration to after all action/discovery registrations for consistency

## Test plan
- [ ] Verify extension starts and responds to `GET /` with an `ETag` header
- [ ] Verify `GET /` with matching `If-None-Match` header returns `304 Not Modified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)